### PR TITLE
fix: 修复windows 10 多显示器缩放截图移位的BUG

### DIFF
--- a/WpfTool/ScreenshotWindow.xaml.cs
+++ b/WpfTool/ScreenshotWindow.xaml.cs
@@ -42,6 +42,7 @@ public partial class ScreenshotWindow
             y = (int)(bounds.Y * _dpiScale);
             width = (int)(bounds.Width * _dpiScale);
             height = (int)(bounds.Height * _dpiScale);
+            bounds = new Rect(x, y, width, height);
             if (x <= ms.X && ms.X < x + width && y <= ms.Y && ms.Y < y + height) break;
         }
 


### PR DESCRIPTION
Fixes #14 